### PR TITLE
Patching SQL injection vulnerability in DOM

### DIFF
--- a/code/DataObjectManager.php
+++ b/code/DataObjectManager.php
@@ -231,7 +231,7 @@ class DataObjectManager extends ComplexTableField
 	        $SNG = singleton($this->sourceClass); 			
 			foreach(parent::Headings() as $field) {
 				if($SNG->hasDatabaseField($field->Name))	
-					$search[] = "UPPER($field->Name) LIKE '%".strtoupper($this->search)."%'";
+					$search[] = "UPPER($field->Name) LIKE '%".Convert::raw2sql(strtoupper($this->search))."%'";
 			}
 			$search_string = "(".implode(" OR ", $search).")";
 		}


### PR DESCRIPTION
The search function in DOM doesn't sanitise input from the user.

Granted, it would be pretty silly of a user to try and hack their own CMS, but if the CMS is comprimised this could be an easy entrance to the DB. Also, it means quoted strings error.
