### PR TITLE
SimpleTinyMCEField - fix

### DIFF
--- a/code/simple_tinymce_field/SimpleTinyMCEField.php
+++ b/code/simple_tinymce_field/SimpleTinyMCEField.php
@@ -183,7 +183,7 @@ class SimpleTinyMCEField extends TextareaField
   private function buildJS()
   {
     $js = sprintf("
-      $(function() {
+		;(function($) {
 				$('#%s').tinymce({
   				  plugins : '%s',
   				  theme : '%s',
@@ -198,7 +198,7 @@ class SimpleTinyMCEField extends TextareaField
   			   content_css : '%s'
   			   %s
 		    });
-		  });",
+		})(jQuery);",
 		  $this->Id(),
 		  $this->getPlugins(),
 		  $this->getTheme(),


### PR DESCRIPTION
i've added a closuse for the jQuery code to avoid conflicts. before my change you couldn't use this kind of field inside a tabbed popup window.
