### PR TITLE
$this->uploadFolder returns the same path as in $file->getFullPath()

### DIFF
--- a/code/FileDataObjectManager.php
+++ b/code/FileDataObjectManager.php
@@ -428,7 +428,7 @@ class FileDataObjectManager extends DataObjectManager
 					$upload_folder = $form->Fields()->fieldByName('UploadedFiles')->uploadFolder;
 					$folder_id = Folder::findOrMake($upload_folder)->ID;
 					if($this->copyOnImport && ($file->ParentID != $folder_id)) {
-						$new_file_path = $this->uploadFolder.'/'.$file->Name;
+						$new_file_path = $upload_folder.'/'.$file->Name;
 						copy($file->getFullPath(), BASE_PATH.'/'.ASSETS_DIR.'/'.$new_file_path);
 						$clone = new $file_class();
 						$clone->Filename = $new_file_path;


### PR DESCRIPTION
$this->uploadFolder seems to return the same path as in $file->getFullPath() when using ImageDataObjectManager for existing files. Changing $new_file_path to $upload_folder means the path can be overridden in the requested form -and ImageDataObjectManager works as expected from existing files (by copying them and creating a new object)
