### PR TITLE
Translation of untranslated string in DataObjectManager_holder.ss

### DIFF
--- a/templates/DataObjectManager_holder.ss
+++ b/templates/DataObjectManager_holder.ss
@@ -1,4 +1,4 @@
 <div class="dataobjectmanager_holder">
 	<h3>$PluralTitle</h3>
-	<p>You may add $PluralTitle once you have saved for the first time.</p>
+	<p><% sprintf(_t('ADDAFTERSAVE','You may add %s once you have saved for the first time.'),$PluralTitle) %></p>
 </div>	


### PR DESCRIPTION
Fix for one untranslated string in DataObjectManager_holder.ss,
new string can be translated like this:
$lang['en_US']['DataObjectManager_holder.ss']['ADDAFTERSAVE'] = 'You may add %s once you have saved for the first time.';
