### PR TITLE
BUGFIX: use $sort_field for query

### DIFF
--- a/code/SortableDataObject.php
+++ b/code/SortableDataObject.php
@@ -101,7 +101,7 @@ class SortableDataObject extends DataObjectDecorator
             if(stristr($from,$join_table)) {
               $sort_field = "\"$join_table\".\"SortOrder\"";
               if(isset($query->select['SortOrder'])) {
-              	$query->select['SortOrder'] = "\"{$this->owner->class}\".SortOrder AS LocalSort";
+              	$query->select['SortOrder'] = "$sort_field AS LocalSort";
               }
               break;
             }


### PR DESCRIPTION
bug in many_many sortable: in a many many relation from eg Page to Image it would try to select Image.SortOrder instead of Page_ImageRelation.SortOrder

Tested with a many_many relation, could you please test it with a has_many as well, it shouldn't effect it I think, but to be sure.
