### PR TITLE
I'm running into an issue where I have multiple DOM instances in the sam...

### DIFF
--- a/javascript/dataobject_manager.js
+++ b/javascript/dataobject_manager.js
@@ -20,7 +20,9 @@ $.fn.DataObjectManager.init = function(obj) {
 				$('#facebox .content').removeClass().addClass('content');
 				$('#facebox_overlay').remove();
 				$('#facebox .loading').remove();
-				refresh($container, $container.attr('href'));
+				$(".DataObjectManager").each(function() {
+					refresh($(this), $(this).attr('href'));
+				});
 			})
 		};
 


### PR DESCRIPTION
...e CMS interface, housing the same DataObjects, and I need them both to update when one changes.  Aside from the minor performance hit, is there any reason not to refresh all present DOMs on the close.facebox event?  Or is there a better way to do this?
