### PR TITLE
fixing sortable DOs when ClickToToggle is enabled

### DIFF
--- a/javascript/dataobject_manager.js
+++ b/javascript/dataobject_manager.js
@@ -172,7 +172,7 @@ $.fn.DataObjectManager.init = function(obj) {
 		// Click function for the LI
 		$container.find('ul:not(.ui-sortable) li.data').unbind('click').click(function(e) {
 			var $this = $(this);
-			if ($this.parent().hasClass('toggleSelect')) {
+			if ($this.parent().parent().hasClass('toggleSelect')) {
 				var $input = $this.find('input'),
 					checker = !$input.attr('checked');
 				//don't ask me wtf is going on here!

--- a/templates/DataObjectManager.ss
+++ b/templates/DataObjectManager.ss
@@ -4,7 +4,7 @@
 		<% if Can(add) %>
 			<a class="popup-button" rel="$PopupWidth" href="$AddLink" alt="add">
 				<span class="uploadlink"><img src="dataobject_manager/images/add.png" alt="" /><% sprintf(_t('DataObjectManager.ADDITEM','Add %s',PR_MEDIUM,'Add [name]'),$AddTitle) %></span>
-			</a>	
+			</a>
 		<% else %>
 		  <h3>$PluralTitle</h3>
 		<% end_if %>
@@ -39,8 +39,8 @@
 		</div>
 	</div>
 	<div class="list column{$Headings.Count}" class="list-holder" style="width:100%;">
-		<div class="dataobject-list">		
-			<ul class="<% if ShowAll %>sortable-{$sourceClass}<% end_if %><% if ClickToToggle %> toggleSelect<% end_if %>">
+		<div class="dataobject-list<% if ClickToToggle %> toggleSelect<% end_if %>">
+			<ul class="<% if ShowAll %>sortable-{$sourceClass}<% end_if %>">
 				<li class="head">
 					<div class="fields-wrap">
 					<% control Headings %>
@@ -87,13 +87,10 @@
 	<div class="bottom-controls">
 		<div class="rounded_table_bottom_right">
 			<div class="rounded_table_bottom_left">
-				<% if Sortable %>
-					<div class="sort-control">
+				<div class="sort-control">
+					<% if Sortable %>
 						<input id="showall-{$id}" type="checkbox" <% if ShowAll %>checked="checked"<% end_if %> value="<% if Paginated %>$ShowAllLink<% else %>$PaginatedLink<% end_if %>" /><label for="showall-{$id}"><% _t('DataObjectManager.DRAGDROP','Allow drag &amp; drop reordering') %></label>
-					</div>
-				<% end_if %>
-				<div class="dataobjectmanager-button">
-					<a href="$ExportLink"><% sprintf(_t('DataObjectManager.EXPORT','Export %s'),$PluralTitle) %></span></a>
+					<% end_if %>
 				</div>
 				<div class="per-page-control">
 					<% if ShowAll %><% else %>$PerPageDropdown<% end_if %>

--- a/templates/RelationDataObjectManager.ss
+++ b/templates/RelationDataObjectManager.ss
@@ -39,8 +39,8 @@
 		</div>
 	</div>
 	<div class="list column{$Headings.Count}" class="list-holder" style="width:100%;">
-		<div class="dataobject-list">	
-			<ul class="<% if ShowAll %>sortable-{$SortableClass}<% end_if %><% if ClickToToggle %> toggleSelect<% end_if %>">
+		<div class="dataobject-list<% if ClickToToggle %> toggleSelect<% end_if %>">
+			<ul class="<% if ShowAll %>sortable-{$SortableClass}<% end_if %>">
 				<li class="head">
 					<div class="fields-wrap">
 					<% control Headings %>
@@ -100,7 +100,7 @@
   					   <input id="only-related-{$id}" type="checkbox" <% if OnlyRelated %>checked="checked"<% end_if %> value="<% if OnlyRelated %>$AllRecordsLink<% else %>$OnlyRelatedLink<% end_if %>" /><label for="only-related-{$id}"><% _t('DataObjectManager.ONLYRELATED','Show only related records') %></label>
             </div>
           <% end_if %>
-			  <% end_if %>				
+			  <% end_if %>
 				<div class="per-page-control">
 					<% if ShowAll %><% else %>$PerPageDropdown<% end_if %>
 				</div>
@@ -108,5 +108,5 @@
 		</div>
 	</div>
 	</div>
-	$ExtraData	
+	$ExtraData
 </div>


### PR DESCRIPTION
ClickToToggle allows the admins to toggle the selected state of a row by clicking the entire row of the DOM rather than just the checkbox or radio button.

This change broke drag and drop reordering because it added a class name to the `<ul>`. That classname has now been moved to the parent div and the JS adjusted for this change.
