### PR TITLE
FIXED: Column names when updating SortOrder

### DIFF
--- a/code/DataObjectManager.php
+++ b/code/DataObjectManager.php
@@ -238,8 +238,12 @@ class DataObjectManager extends ComplexTableField
 			$search = array();
 	        $SNG = singleton($this->sourceClass);
 			foreach(parent::Headings() as $field) {
+				// If the source class doesn't own this field, then its parent might.
+				while(!$SNG->hasOwnTableDatabaseField($field->Name) && $parentKls = get_parent_class($SNG->class)) {
+					$SNG = singleton($parentKls);
+				}
 				if($SNG->hasDatabaseField($field->Name))
-					$search[] = "UPPER({$this->sourceClass}.$field->Name) LIKE '%".Convert::raw2sql(strtoupper($this->search))."%'";
+					$search[] = "UPPER({$SNG->class}.$field->Name) LIKE '%".Convert::raw2sql(strtoupper($this->search))."%'";
 			}
 			if(!empty($search)) {
 				$search_string = "(".implode(" OR ", $search).")";


### PR DESCRIPTION
The SortOrder update query was using arbitrary fields to update, which
caused a bug with Page-Page self referencing many many relationships.
The query has been changed to use the Sapphire ORM-reported column
names, which stops the erroneous query logic like WHERE PageID = 1 AND
PageID = 2 and now uses WHERE PageID = 1 AND ChildID = 2, where ChildID
is reported as the correct field by Sapphire.

Line endings have been trimmed. The changed fields are between lines 778 and 780.
