### PR TITLE
Hide edit/delete links based on canEdit(), etc.

### DIFF
--- a/code/DataObjectManager.php
+++ b/code/DataObjectManager.php
@@ -712,7 +712,9 @@ class DataObjectManager_Item extends ComplexTableField_Item {
 	     $action = false;
 	     switch($perm) {
 	       case "edit":
+	       	 if(!$this->item->canEdit()) continue;
 	       case "view":
+	       	 if(!$this->item->canView()) continue;
 	         $actions->push(new DataObjectManagerAction(
 	           $this->ViewOrEdit_i18n(),
 	           $this->EditLink(),
@@ -724,6 +726,7 @@ class DataObjectManager_Item extends ComplexTableField_Item {
 	       break;
 
 	       case "delete":
+	       	 if(!$this->item->canDelete()) continue;
 	         $actions->push(new DataObjectManagerAction(
 	           _t('DataObjectManager.DELETE','Delete'),
 	           $this->DeleteLink(),
@@ -735,6 +738,7 @@ class DataObjectManager_Item extends ComplexTableField_Item {
 	       break;
 
 	       case "duplicate":
+	       	 if(!$this->item->canCreate()) continue;
 	         $actions->push(new DataObjectManagerAction(
 	           _t('DataObjectManager.DUPLICATE','Duplicate'),
 	           $this->DuplicateLink(),


### PR DESCRIPTION
This is a quick-n'-dirty patch to make DOM hide "action" links such as edit and delete based on per-item permissions (i.e., addresses issue #75). While a more complete solution is needed (there are other points in the code that should be updated), it does only show the action links when those actions are allowed.
